### PR TITLE
issue 89: Fix age bound units on Query page

### DIFF
--- a/website/public/modules/ng_create.js
+++ b/website/public/modules/ng_create.js
@@ -1465,8 +1465,7 @@ var create = (function(){
           "radio carbon year before present",
           "billion years ago",
           "calendar kiloyear before present",
-          "radiocarbon kiloyear before present",
-          "calendar kiloyear before present"
+          "radiocarbon kiloyear before present"
       ];
     }),
 


### PR DESCRIPTION
Age bound units would not properly render because there was a duplicate in the dropdown list and angular was erroring. 